### PR TITLE
feat: add Path of Building PoE1 package

### DIFF
--- a/modules/home-manager/desktop/desktop-apps.nix
+++ b/modules/home-manager/desktop/desktop-apps.nix
@@ -25,6 +25,7 @@ in
     godot
     prismlauncher # Minecraft launcher
     localPkgs.awakened-poe-trade # Path of Exile trade overlay
+    localPkgs.pob-poe1 # Path of Building PoE1 (via Wine)
     localPkgs.pob-poe2 # Path of Building PoE2 (via Wine)
     heroic # Epic Games/GOG launcher
     umu-launcher # Unified launcher for Proton outside Steam

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,5 +1,9 @@
 pkgs: {
   awakened-poe-trade = pkgs.callPackage ./awakened-poe-trade { };
+  pob-poe1 = pkgs.callPackage ./pob-poe1 {
+    wine = pkgs.wineWow64Packages.stable;
+  };
+
   pob-poe2 = pkgs.callPackage ./pob-poe2 {
     wine = pkgs.wineWow64Packages.stable;
   };

--- a/pkgs/pob-poe1/default.nix
+++ b/pkgs/pob-poe1/default.nix
@@ -1,0 +1,91 @@
+{
+  lib,
+  fetchurl,
+  stdenv,
+  unzip,
+  wine,
+  copyDesktopItems,
+  makeDesktopItem,
+  nix-update-script,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "pob-poe1";
+  version = "2.65.0";
+
+  src = fetchurl {
+    url = "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/download/v${finalAttrs.version}/PathOfBuildingCommunity-Portable.zip";
+    hash = "sha256-UB/JVvc7jdGKKrIDN8vbfQbWQYs01H9hRAgjTiUjhcQ=";
+  };
+
+  nativeBuildInputs = [ unzip copyDesktopItems ];
+
+  dontUnpack = true;
+
+  desktopItems = [
+    (makeDesktopItem {
+      name = "pob-poe1";
+      desktopName = "Path of Building (PoE1)";
+      comment = "Offline build planner for Path of Exile 1 (Community Fork)";
+      exec = "pob-poe1";
+      terminal = false;
+      type = "Application";
+      icon = "pob-poe1";
+      categories = [ "Game" ];
+      keywords = [ "poe" "pob" "path" "exile" ];
+    })
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/bin $out/lib/pob-poe1
+    unzip $src -d $out/lib/pob-poe1
+    mv "$out/lib/pob-poe1/Path of Building.exe" "$out/lib/pob-poe1/pob-poe1.exe"
+    chmod +x "$out/lib/pob-poe1/pob-poe1.exe"
+    echo "$out/lib/pob-poe1" > "$out/lib/pob-poe1/.store-path"
+    runHook postInstall
+  '';
+
+  postFixup = ''
+    echo '#!${stdenv.shell}' -e > $out/bin/pob-poe1
+    echo "STORE_SRC='$out/lib/pob-poe1'" >> $out/bin/pob-poe1
+    echo "WINE='${lib.getExe wine}'" >> $out/bin/pob-poe1
+    cat >> $out/bin/pob-poe1 << 'WRAPPER'
+LOCAL_DIR="$HOME/.local/share/pob-poe1"
+STORE_PATH_FILE="$LOCAL_DIR/.store-path"
+
+needs_copy=false
+if [ ! -f "$STORE_PATH_FILE" ]; then
+  needs_copy=true
+elif [ "$(cat "$STORE_PATH_FILE" 2>/dev/null)" != "$STORE_SRC" ]; then
+  needs_copy=true
+fi
+
+if [ "$needs_copy" = true ]; then
+  rm -rf "$LOCAL_DIR"
+  mkdir -p "$LOCAL_DIR"
+  cp -r "$STORE_SRC"/. "$LOCAL_DIR/"
+  echo "$STORE_SRC" > "$LOCAL_DIR/.store-path"
+fi
+
+for var in http_proxy https_proxy ftp_proxy rsync_proxy all_proxy no_proxy HTTP_PROXY HTTPS_PROXY FTP_PROXY RSYNC_PROXY ALL_PROXY NO_PROXY; do
+  unset "$var"
+done
+
+exec "$WINE" "$LOCAL_DIR/pob-poe1.exe" "$@"
+WRAPPER
+    chmod +x $out/bin/pob-poe1
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = {
+    description = "Offline build planner for Path of Exile 1 (Community Fork)";
+    homepage = "https://github.com/PathOfBuildingCommunity/PathOfBuilding";
+    changelog = "https://github.com/PathOfBuildingCommunity/PathOfBuilding/releases/tag/v${finalAttrs.version}";
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "pob-poe1";
+  };
+})

--- a/scripts/check-poe-updates.sh
+++ b/scripts/check-poe-updates.sh
@@ -29,13 +29,23 @@ if [ -f "$apt_pkg" ]; then
   fi
 fi
 
+# pob-poe1
+pob1_pkg="$REPO_DIR/pkgs/pob-poe1/default.nix"
+if [ -f "$pob1_pkg" ]; then
+  current_pob1="$(extract_version "$pob1_pkg")"
+  latest_pob1="$(fetch_latest_tag "PathOfBuildingCommunity/PathOfBuilding" || true)"
+  if [ -n "$latest_pob1" ] && [ "$current_pob1" != "$latest_pob1" ]; then
+    updates+=("Path of Building PoE1: $current_pob1 → $latest_pob1")
+  fi
+fi
+
 # pob-poe2
-pob_pkg="$REPO_DIR/pkgs/pob-poe2/default.nix"
-if [ -f "$pob_pkg" ]; then
-  current_pob="$(extract_version "$pob_pkg")"
-  latest_pob="$(fetch_latest_tag "PathOfBuildingCommunity/PathOfBuilding-PoE2" || true)"
-  if [ -n "$latest_pob" ] && [ "$current_pob" != "$latest_pob" ]; then
-    updates+=("Path of Building PoE2: $current_pob → $latest_pob")
+pob2_pkg="$REPO_DIR/pkgs/pob-poe2/default.nix"
+if [ -f "$pob2_pkg" ]; then
+  current_pob2="$(extract_version "$pob2_pkg")"
+  latest_pob2="$(fetch_latest_tag "PathOfBuildingCommunity/PathOfBuilding-PoE2" || true)"
+  if [ -n "$latest_pob2" ] && [ "$current_pob2" != "$latest_pob2" ]; then
+    updates+=("Path of Building PoE2: $current_pob2 → $latest_pob2")
   fi
 fi
 

--- a/update.sh
+++ b/update.sh
@@ -9,6 +9,10 @@ echo "=== Updating awakened-poe-trade ==="
 nix-update --file "$SCRIPT_DIR/pkgs/awakened-poe-trade" --version=bump
 
 echo ""
+echo "=== Updating pob-poe1 ==="
+nix-update --file "$SCRIPT_DIR/pkgs/pob-poe1" --version=bump
+
+echo ""
 echo "=== Updating pob-poe2 ==="
 nix-update --file "$SCRIPT_DIR/pkgs/pob-poe2" --version=bump
 


### PR DESCRIPTION
Add `pob-poe1` package — Path of Building Community Fork for Path of Exile 1, runs via Wine.

- `pkgs/pob-poe1/default.nix` — new package, mirrors `pob-poe2`
- `pkgs/default.nix` — register `pob-poe1` with `wineWow64Packages.stable`
- `modules/home-manager/desktop/desktop-apps.nix` — add to user packages
- `scripts/check-poe-updates.sh` — add PoB PoE1 version check
- `update.sh` — add `pob-poe1` bump target

Validate: `nix flake check` passes.