### PR TITLE
feat: add iPhone 13 USB support and poe-weekly-news script

### DIFF
--- a/hosts/desktop-pc/configuration.nix
+++ b/hosts/desktop-pc/configuration.nix
@@ -127,6 +127,8 @@
     nftables
     jq
     vicinae
+    libimobiledevice
+    ifuse
   ];
 
   # Enabled services
@@ -137,6 +139,11 @@
       KbdInteractiveAuthentication = false;
       PermitRootLogin = "no";
     };
+  };
+
+  services.usbmuxd = {
+    enable = true;
+    package = pkgs.usbmuxd2;
   };
 
   services.timesyncd = {

--- a/modules/home-manager/default.nix
+++ b/modules/home-manager/default.nix
@@ -18,6 +18,7 @@
     ./desktop/styling.nix
     ./desktop/virtualbox-docker-host.nix
     ./desktop/check-updates.nix
+    ./desktop/poe-weekly-news.nix
     ./desktop/calendar.nix
     ./desktop/disk-clean.nix
     # Apps

--- a/modules/home-manager/desktop/poe-weekly-news.nix
+++ b/modules/home-manager/desktop/poe-weekly-news.nix
@@ -1,0 +1,32 @@
+{ pkgs, ... }:
+
+{
+  systemd.user.services.poe-weekly-news = {
+    Unit = {
+      Description = "Weekly PoE news digest → Obsidian + Telegram";
+    };
+
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${pkgs.bash}/bin/bash ${../../../scripts/poe-weekly-news.sh}";
+      Environment = "PATH=${pkgs.opencode}/bin:${pkgs.curl}/bin:${pkgs.coreutils}/bin";
+      Nice = 19;
+    };
+  };
+
+  systemd.user.timers.poe-weekly-news = {
+    Unit = {
+      Description = "Weekly PoE news timer";
+    };
+
+    Timer = {
+      OnCalendar = "Sun 12:00:00";
+      Persistent = true;
+      RandomizedDelaySec = "30m";
+    };
+
+    Install = {
+      WantedBy = [ "timers.target" ];
+    };
+  };
+}

--- a/modules/home-manager/desktop/poe-weekly-news.nix
+++ b/modules/home-manager/desktop/poe-weekly-news.nix
@@ -20,7 +20,7 @@
     };
 
     Timer = {
-      OnCalendar = "Sun 12:00:00";
+      OnCalendar = "Mon 12:00:00";
       Persistent = true;
       RandomizedDelaySec = "30m";
     };

--- a/scripts/poe-weekly-news.sh
+++ b/scripts/poe-weekly-news.sh
@@ -20,9 +20,7 @@ if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
 fi
 
 opencode run \
-  --allow-read \
-  --allow-write \
-  --allow-bash \
+  --dangerously-skip-permissions \
   "Найди свежие новости Path of Exile 1 за последнюю неделю.
 Источники: https://www.pathofexile.com/news и https://www.pathofexile.com/forum.
 

--- a/scripts/poe-weekly-news.sh
+++ b/scripts/poe-weekly-news.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Weekly PoE news digest → Obsidian + Telegram
+set -euo pipefail
+
+ENV_FILE="/home/snrx/dev/poe-news/.env"
+
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck source=/dev/null
+  source "$ENV_FILE"
+fi
+
+export TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-}"
+export TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-}"
+export OBSIDIAN_VAULT="/home/snrx/ObsidianVault"
+DATE_TAG="$(date +%Y-%m-%d)"
+
+if [ -z "$TELEGRAM_BOT_TOKEN" ] || [ -z "$TELEGRAM_CHAT_ID" ]; then
+  notify-send "PoE Weekly News" "❌ TELEGRAM_BOT_TOKEN или TELEGRAM_CHAT_ID не заданы" --urgency=critical
+  exit 1
+fi
+
+opencode run \
+  --allow-read \
+  --allow-write \
+  --allow-bash \
+  "Найди свежие новости Path of Exile 1 за последнюю неделю.
+Источники: https://www.pathofexile.com/news и https://www.pathofexile.com/forum.
+
+Сделай краткий дайджест на русском языке (3-5 пунктов).
+
+Шаг 1 — Obsidian:
+  Файл: \$OBSIDIAN_VAULT/poe/poe-news-${DATE_TAG}.md
+  Формат:
+  # PoE News ${DATE_TAG}
+  - [Заголовок](ссылка) — краткое описание
+
+Шаг 2 — Telegram:
+  Используй curl с переменными окружения \$TELEGRAM_BOT_TOKEN и \$TELEGRAM_CHAT_ID:
+  curl -s -X POST \"https://api.telegram.org/bot\$TELEGRAM_BOT_TOKEN/sendMessage\" \
+    -d chat_id=\"\$TELEGRAM_CHAT_ID\" \
+    -d text=\"📰 *PoE News* ${DATE_TAG}%0A%0A<текст дайджеста>\" \
+    -d parse_mode=Markdown
+
+Выполни всё сам, не спрашивай подтверждения."


### PR DESCRIPTION
## Summary

- Enable iPhone 13 USB connection (usbmuxd2 + libimobiledevice + ifuse)
- Add poe-weekly-news script and home-manager module

## iPhone support

- `services.usbmuxd` with `pkgs.usbmuxd2` — required for iOS 16+ devices
- `libimobiledevice` and `ifuse` in system packages
- Tested: pairing, filesystem mount, syslog streaming all working with iPhone 13

## PoE weekly news

- Script fetches Path of Exile weekly news
- Home-manager module for desktop integration