### PR TITLE
fix: use niri focused-output for screenshot-full

### DIFF
--- a/modules/home-manager/desktop/niri-noctalia.nix
+++ b/modules/home-manager/desktop/niri-noctalia.nix
@@ -215,7 +215,7 @@ in
       dir="$HOME/Pictures/Screenshots"
       mkdir -p "$dir"
       file="$dir/$(date +%Y-%m-%d_%H-%M-%S).png"
-      output=$(${pkgs.niri}/bin/niri msg -j outputs | ${pkgs.jq}/bin/jq -r '.[] | select(.is_focused) | .name')
+      output=$(${pkgs.niri}/bin/niri msg -j focused-output | ${pkgs.jq}/bin/jq -r '.name')
       ${pkgs.grim}/bin/grim -o "$output" "$file"
       ${pkgs.wl-clipboard}/bin/wl-copy < "$file"
       ${pkgs.libnotify}/bin/notify-send "Screenshot saved" "$(basename "$file")"


### PR DESCRIPTION
## Summary
- `screenshot-full` used `niri msg -j outputs | jq '.[] | select(.is_focused)'` — but `outputs` returns an object (not array) and lacks `is_focused` field
- `grim -o ""` failed silently, no file saved
- Fixed to use `niri msg -j focused-output | jq -r '.name'`

## Validation
- `nix flake check` passes
- `niri msg -j focused-output | jq -r '.name'` returns `DP-1`