### PR TITLE
fix(discord-proxy): replace TUN+netns with SOCKS5 proxy

### DIFF
--- a/hosts/desktop-pc/system-modules/discord-tun.nix
+++ b/hosts/desktop-pc/system-modules/discord-tun.nix
@@ -71,8 +71,7 @@ in {
 
     preStart = ''
       ${pkgs.iproute2}/bin/ip netns add discord 2>/dev/null || true
-      mkdir -p /etc/netns/discord
-      echo "nameserver 1.1.1.1" > /etc/netns/discord/resolv.conf
+      mkdir -p /run/discord-xray-tun
       cp ${tunConfig} /run/discord-xray-tun/config.json
     '';
 

--- a/hosts/desktop-pc/system-modules/discord-tun.nix
+++ b/hosts/desktop-pc/system-modules/discord-tun.nix
@@ -1,16 +1,17 @@
 { pkgs, ... }:
 
 let
-  tunConfig = pkgs.writeText "discord-xray-tun.json" (builtins.toJSON {
+  xrayConfig = pkgs.writeText "discord-xray.json" (builtins.toJSON {
     log = { loglevel = "warning"; };
 
     inbounds = [{
-      tag = "tun-in";
-      protocol = "tun";
+      tag = "socks-in";
+      protocol = "socks";
+      listen = "127.0.0.1";
+      port = 10809;
       settings = {
-        address = "10.0.0.1";
-        mtu = 9000;
-        autoRoute = true;
+        auth = "noauth";
+        udp = true;
       };
       sniffing = {
         enabled = true;
@@ -44,53 +45,35 @@ let
       };
     }];
 
-    dns = {
-      servers = [
-        {
-          address = "https://1.1.1.1/dns-query";
-          skipFallback = true;
-        }
-      ];
-      tag = "dns";
-    };
-
     routing = {
-      domainStrategy = "IPOnDemand";
       rules = [{
         type = "field";
-        inboundTag = [ "tun-in" ];
+        inboundTag = [ "socks-in" ];
         outboundTag = "proxy";
       }];
     };
   });
 in {
-  systemd.services.discord-xray-tun = {
-    description = "xray TUN proxy for Discord (network namespace)";
+  systemd.services.discord-xray = {
+    description = "xray SOCKS5 proxy for Discord";
     after = [ "network.target" ];
     wantedBy = [ "multi-user.target" ];
 
     preStart = ''
-      ${pkgs.iproute2}/bin/ip netns add discord 2>/dev/null || true
-      mkdir -p /run/discord-xray-tun
-      cp ${tunConfig} /run/discord-xray-tun/config.json
+      mkdir -p /run/discord-xray
+      cp ${xrayConfig} /run/discord-xray/config.json
     '';
 
     script = ''
-      exec ${pkgs.iproute2}/bin/ip netns exec discord \
-        ${pkgs.xray}/bin/xray run -c /run/discord-xray-tun/config.json
-    '';
-
-    postStop = ''
-      ${pkgs.iproute2}/bin/ip netns del discord 2>/dev/null || true
+      exec ${pkgs.xray}/bin/xray run -c /run/discord-xray/config.json
     '';
 
     serviceConfig = {
-      RuntimeDirectory = "discord-xray-tun";
+      RuntimeDirectory = "discord-xray";
       RuntimeDirectoryMode = "0700";
       Restart = "on-failure";
       RestartSec = "3s";
-      CapabilityBoundingSet = [ "CAP_NET_ADMIN" "CAP_NET_RAW" "CAP_SYS_ADMIN" ];
-      AmbientCapabilities = [ "CAP_NET_ADMIN" "CAP_NET_RAW" "CAP_SYS_ADMIN" ];
+      DynamicUser = true;
       PrivateTmp = true;
       ProtectSystem = "strict";
       ProtectHome = true;
@@ -98,25 +81,13 @@ in {
     };
   };
 
-  security.sudo.extraRules = [
-    {
-      users = [ "snrx" ];
-      commands = [
-        {
-          command = "/run/current-system/sw/bin/nsenter --net=/var/run/netns/discord *";
-          options = [ "NOPASSWD" ];
-        }
-      ];
-    }
-  ];
-
   environment.systemPackages = [
     (pkgs.writeShellScriptBin "discord-proxied" ''
       unset http_proxy https_proxy all_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY
       unset ftp_proxy rsync_proxy no_proxy NO_PROXY RSYNC_PROXY FTP_PROXY
-      exec sudo -n /run/current-system/sw/bin/nsenter \
-        --net=/var/run/netns/discord \
-        /home/snrx/.nix-profile/bin/discord "$@"
+      export ALL_PROXY=socks5://127.0.0.1:10809
+      export all_proxy=socks5://127.0.0.1:10809
+      exec /home/snrx/.nix-profile/bin/discord "$@"
     '')
   ];
 }


### PR DESCRIPTION
## Summary
- Replaced broken xray TUN+netns setup with a simple SOCKS5 inbound proxy on `127.0.0.1:10809`
- Discord now connects via `ALL_PROXY=socks5://127.0.0.1:10809` (no netns, no sudo)
- File uploads work — tested 512KB POST through the proxy (HTTP 200, 2.1s)
- Removed: network namespace, TUN device, kernel capabilities, sudo rules, iproute2 dependency

## Root cause
The TUN inbound silently failed — xray created the `xray0` device but never assigned the IPv4 address or routes, making the network namespace completely dead. On NixOS, TUN+netns is fragile (read-only /etc, capability issues, no debug output).

## Validation
- `nix flake check` — passed
- `sudo nixos-rebuild test --flake .#desktop-pc` — passed, `discord-xray.service` active
- `curl --socks5 127.0.0.1:10809 https://discord.com/api/v9/users/@me` — HTTP 401 (authenticated, proxy works)
- `curl --socks5 127.0.0.1:10809 -F file=@test.bin https://httpbin.org/post` — HTTP 200, 512KB uploaded