### PR TITLE
fix: Discord UDP proxy + screenshot-window keybind

### DIFF
--- a/hosts/desktop-pc/system-modules/default.nix
+++ b/hosts/desktop-pc/system-modules/default.nix
@@ -10,7 +10,7 @@
     ./users.nix
     ./virtualbox-safe-power.nix
     ./virtualbox-host.nix
-    ./discord-tun.nix
+    ./discord-udp-proxy.nix
     ./zsh.nix
     ./cpu.nix
     ./docker.nix

--- a/hosts/desktop-pc/system-modules/discord-udp-proxy.nix
+++ b/hosts/desktop-pc/system-modules/discord-udp-proxy.nix
@@ -1,0 +1,113 @@
+{ pkgs, ... }:
+
+let
+  redirectPort = "12345";
+  discordUdpPorts = "1024:65535";
+  fwmark = "0x1";
+  table = "100";
+
+  xrayConfig = pkgs.writeText "discord-udp-xray.json" (builtins.toJSON {
+    log = { loglevel = "warning"; };
+
+    inbounds = [{
+      tag = "discord-udp-redirect";
+      listen = "0.0.0.0";
+      port = 12345;
+      protocol = "dokodemo-door";
+      settings = {
+        network = "udp";
+        followRedirect = true;
+      };
+      streamSettings = {
+        sockopt = { tproxy = "redirect"; };
+      };
+    }];
+
+    outbounds = [{
+      tag = "proxy";
+      protocol = "vless";
+      settings = {
+        vnext = [{
+          address = "lv1node.soon.it";
+          port = 8443;
+          users = [{
+            id = "25788ada-ab4c-47ab-a00e-cbba5edb4a8e";
+            flow = "xtls-rprx-vision";
+            encryption = "none";
+          }];
+        }];
+      };
+      streamSettings = {
+        network = "tcp";
+        security = "reality";
+        realitySettings = {
+          fingerprint = "firefox";
+          serverName = "lv1node.soon.it";
+          publicKey = "tpjqqi2FPGZ1nWHbRxka800TFg-J1_OMvJ04oUC4kkA";
+          shortId = "b0dbd85b5a3fb62a";
+        };
+      };
+    }];
+
+    routing = {
+      domainStrategy = "IPIfNonMatch";
+      rules = [{
+        type = "field";
+        inboundTag = [ "discord-udp-redirect" ];
+        outboundTag = "proxy";
+      }];
+    };
+  });
+in {
+  systemd.services.discord-udp-xray = {
+    description = "Transparent Xray proxy for Discord UDP";
+    wantedBy = [ "multi-user.target" ];
+    wants = [ "network-online.target" ];
+    after = [ "network-online.target" ];
+
+    preStart = ''
+      cp ${xrayConfig} "$RUNTIME_DIRECTORY/config.json"
+      ${pkgs.xray}/bin/xray run -test -c "$RUNTIME_DIRECTORY/config.json"
+    '';
+
+    serviceConfig = {
+      ExecStart = "${pkgs.xray}/bin/xray run -c /run/discord-udp-xray/config.json";
+      RuntimeDirectory = "discord-udp-xray";
+      RuntimeDirectoryMode = "0700";
+      Restart = "on-failure";
+      RestartSec = "3s";
+      PrivateTmp = true;
+      ProtectSystem = "strict";
+      ProtectHome = "read-only";
+      RestrictRealtime = true;
+      RestrictSUIDSGID = true;
+      SystemCallArchitectures = "native";
+    };
+  };
+
+  networking.firewall = {
+    extraCommands = ''
+      ${pkgs.iptables}/bin/iptables -w -t nat -D OUTPUT -p udp -m multiport --dports ${discordUdpPorts} -m addrtype ! --dst-type LOCAL -j REDIRECT --to-ports ${redirectPort} 2>/dev/null || true
+      ${pkgs.iptables}/bin/iptables -w -t mangle -D POSTROUTING -p udp -m multiport --dports ${discordUdpPorts} -m mark ! --mark 0x40000000/0x40000000 -j NFQUEUE --queue-num 200 --queue-bypass 2>/dev/null || true
+      ${pkgs.iptables}/bin/iptables -w -t mangle -D POSTROUTING -p tcp --dport 80 -m connbytes --connbytes-dir original --connbytes-mode packets --connbytes 1:6 -m mark ! --mark 0x40000000/0x40000000 -j NFQUEUE --queue-num 200 --queue-bypass 2>/dev/null || true
+      ${pkgs.iptables}/bin/iptables -w -t mangle -D POSTROUTING -p tcp --dport 443 -m connbytes --connbytes-dir original --connbytes-mode packets --connbytes 1:6 -m mark ! --mark 0x40000000/0x40000000 -j NFQUEUE --queue-num 200 --queue-bypass 2>/dev/null || true
+
+      ${pkgs.iproute2}/bin/ip rule add fwmark ${fwmark}/${fwmark} table ${table} 2>/dev/null || true
+      ${pkgs.iproute2}/bin/ip route replace local 0.0.0.0/0 dev lo table ${table}
+
+      ${pkgs.iptables}/bin/iptables -w -t mangle -C OUTPUT -p udp -m multiport --dports ${discordUdpPorts} -m addrtype ! --dst-type LOCAL -j MARK --set-mark ${fwmark} 2>/dev/null \
+        || ${pkgs.iptables}/bin/iptables -w -t mangle -A OUTPUT -p udp -m multiport --dports ${discordUdpPorts} -m addrtype ! --dst-type LOCAL -j MARK --set-mark ${fwmark}
+
+      ${pkgs.iptables}/bin/iptables -w -t mangle -C PREROUTING -p udp -m mark --mark ${fwmark}/${fwmark} -j TPROXY --on-port ${redirectPort} --tproxy-mark ${fwmark}/${fwmark} 2>/dev/null \
+        || ${pkgs.iptables}/bin/iptables -w -t mangle -A PREROUTING -p udp -m mark --mark ${fwmark}/${fwmark} -j TPROXY --on-port ${redirectPort} --tproxy-mark ${fwmark}/${fwmark}
+    '';
+
+    extraStopCommands = ''
+      ${pkgs.iptables}/bin/iptables -w -t nat -D OUTPUT -p udp -m multiport --dports ${discordUdpPorts} -m addrtype ! --dst-type LOCAL -j REDIRECT --to-ports ${redirectPort} 2>/dev/null || true
+      ${pkgs.iptables}/bin/iptables -w -t mangle -D OUTPUT -p udp -m multiport --dports ${discordUdpPorts} -m addrtype ! --dst-type LOCAL -j MARK --set-mark ${fwmark} 2>/dev/null || true
+      ${pkgs.iptables}/bin/iptables -w -t mangle -D PREROUTING -p udp -m mark --mark ${fwmark}/${fwmark} -j TPROXY --on-port ${redirectPort} --tproxy-mark ${fwmark}/${fwmark} 2>/dev/null || true
+      ${pkgs.iproute2}/bin/ip route flush table ${table} 2>/dev/null || true
+      ${pkgs.iproute2}/bin/ip rule del fwmark ${fwmark}/${fwmark} table ${table} 2>/dev/null || true
+    '';
+  };
+}

--- a/modules/home-manager/apps/discord.nix
+++ b/modules/home-manager/apps/discord.nix
@@ -1,7 +1,28 @@
 { pkgs, ... }:
+let
+  discord-override = pkgs.discord.override {
+    commandLineArgs = "--proxy-server=socks5://127.0.0.1:10808 --disable-quic";
+  };
+
+  discord-wrapped = pkgs.symlinkJoin {
+    name = "discord";
+    paths = [ discord-override ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram "$out/bin/discord" \
+        --unset http_proxy \
+        --unset https_proxy \
+        --unset all_proxy \
+        --unset HTTP_PROXY \
+        --unset HTTPS_PROXY \
+        --unset ALL_PROXY
+    '';
+  };
+in
 {
   programs.discord = {
     enable = true;
+    package = discord-wrapped;
     settings = {
       SKIP_HOST_UPDATE = true;
     };

--- a/modules/home-manager/desktop/desktop-apps.nix
+++ b/modules/home-manager/desktop/desktop-apps.nix
@@ -52,6 +52,7 @@ in
     grim
     slurp
     wf-recorder
+    imagemagick
     protonplus
   ];
 

--- a/modules/home-manager/desktop/niri-noctalia.nix
+++ b/modules/home-manager/desktop/niri-noctalia.nix
@@ -199,6 +199,33 @@ in
     rsync
     wl-clipboard
     xwayland-satellite
+    (pkgs.writeShellScriptBin "screenshot-window" ''
+      dir="$HOME/Pictures/Screenshots"
+      mkdir -p "$dir"
+      file="$dir/$(date +%Y-%m-%d_%H-%M-%S).png"
+
+      win_data=$(${pkgs.niri}/bin/niri msg -j windows | ${pkgs.jq}/bin/jq '[.[] | select(.is_focused)] | first')
+      if [ -z "$win_data" ] || [ "$win_data" = "null" ]; then
+        ${pkgs.libnotify}/bin/notify-send "Screenshot error" "No focused window"
+        exit 1
+      fi
+
+      out_name=$(echo "$win_data" | ${pkgs.jq}/bin/jq -r '.output')
+      win_x=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.geometry.x // 0')
+      win_y=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.geometry.y // 0')
+      win_w=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.geometry.width // 0')
+      win_h=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.geometry.height // 0')
+
+      if [ "$win_w" -eq 0 ] || [ "$win_h" -eq 0 ]; then
+        ${pkgs.libnotify}/bin/notify-send "Screenshot error" "Could not get window geometry"
+        exit 1
+      fi
+
+      ${pkgs.grim}/bin/grim -o "$out_name" - | \
+        ${pkgs.imagemagick}/bin/convert - -crop "$win_w"x"$win_h"+"$win_x"+"$win_y" "$file"
+      ${pkgs.wl-clipboard}/bin/wl-copy < "$file"
+      ${pkgs.libnotify}/bin/notify-send "Screenshot saved" "$(basename "$file")"
+    '')
     (pkgs.writeShellScriptBin "screenshot-annotate" ''
       dir="$HOME/Pictures/Screenshots"
       mkdir -p "$dir"
@@ -407,7 +434,7 @@ in
     spawn-at-startup "Telegram"
     spawn-at-startup "KeePassXC"
     spawn-at-startup "spotify"
-    spawn-at-startup "sh" "-c" "${pkgs.coreutils}/bin/sleep 20; exec discord-proxied"
+    spawn-at-startup "discord"
 
     binds {
         Mod+Return { spawn "ghostty"; }
@@ -467,6 +494,7 @@ in
 
         Print { spawn "screenshot-annotate"; }
         Shift+Print { spawn "screenshot-full"; }
+        Mod+Print { spawn "screenshot-window"; }
 
         XF86AudioRaiseVolume allow-when-locked=true { ${noctalia ''"volume" "increase"''}; }
         XF86AudioLowerVolume allow-when-locked=true { ${noctalia ''"volume" "decrease"''}; }

--- a/modules/home-manager/desktop/niri-noctalia.nix
+++ b/modules/home-manager/desktop/niri-noctalia.nix
@@ -216,26 +216,16 @@ in
         out_name=$(${pkgs.niri}/bin/niri msg -j focused-output | ${pkgs.jq}/bin/jq -r '.name')
       fi
 
-      col=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.pos_in_scrolling_layout[0]')
-      row=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.pos_in_scrolling_layout[1]')
       win_w=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.window_size[0]')
       win_h=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.window_size[1]')
-      off_x=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.window_offset_in_tile[0]')
-      off_y=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.window_offset_in_tile[1]')
 
       if [ "$win_w" -eq 0 ] || [ "$win_h" -eq 0 ]; then
         ${pkgs.libnotify}/bin/notify-send "Screenshot error" "Could not get window geometry"
         exit 1
       fi
 
-      gap=8
-      prev_h=$(echo "$all_win" | ${pkgs.jq}/bin/jq \
-        "[.[] | select(.output == \"$out_name\" and .layout.pos_in_scrolling_layout[0] == $col and .layout.pos_in_scrolling_layout[1] < $row) | .layout.tile_size[1]] | add // 0")
-      prev_w=$(echo "$all_win" | ${pkgs.jq}/bin/jq \
-        "[.[] | select(.output == \"$out_name\" and .layout.pos_in_scrolling_layout[0] < $col and .layout.pos_in_scrolling_layout[1] == $row) | .layout.tile_size[0]] | add // 0")
-
-      win_x=$(echo "$prev_w $col $gap $off_x" | ${pkgs.coreutils}/bin/awk '{print int($1 + ($2 - 1) * $3 + $3 + $4)}')
-      win_y=$(echo "$prev_h $row $gap $off_y" | ${pkgs.coreutils}/bin/awk '{print int($1 + ($2 - 1) * $3 + $3 + $4)}')
+      win_x=8
+      win_y=8
 
       tmp_file=$(${pkgs.coreutils}/bin/mktemp --suffix=.png)
       ${pkgs.grim}/bin/grim -o "$out_name" "$tmp_file"

--- a/modules/home-manager/desktop/niri-noctalia.nix
+++ b/modules/home-manager/desktop/niri-noctalia.nix
@@ -237,9 +237,22 @@ in
       win_x=$(echo "$prev_w $col $gap $off_x" | ${pkgs.coreutils}/bin/awk '{print int($1 + ($2 - 1) * $3 + $3 + $4)}')
       win_y=$(echo "$prev_h $row $gap $off_y" | ${pkgs.coreutils}/bin/awk '{print int($1 + ($2 - 1) * $3 + $3 + $4)}')
 
-      ${pkgs.grim}/bin/grim -o "$out_name" - | \
-        ${pkgs.imagemagick}/bin/convert - -crop "$win_w"x"$win_h"+"$win_x"+"$win_y" "$file"
-      ${pkgs.wl-clipboard}/bin/wl-copy < "$file"
+      tmp_file=$(${pkgs.coreutils}/bin/mktemp --suffix=.png)
+      ${pkgs.grim}/bin/grim -o "$out_name" "$tmp_file"
+      if [ $? -ne 0 ]; then
+        ${pkgs.coreutils}/bin/rm -f "$tmp_file"
+        ${pkgs.libnotify}/bin/notify-send "Screenshot error" "grim capture failed"
+        exit 1
+      fi
+
+      ${pkgs.imagemagick}/bin/convert "$tmp_file" -crop "$win_w"x"$win_h"+"$win_x"+"$win_y" "$file"
+      crop_rc=$?
+      ${pkgs.coreutils}/bin/rm -f "$tmp_file"
+      if [ $crop_rc -ne 0 ]; then
+        ${pkgs.libnotify}/bin/notify-send "Screenshot error" "Crop failed"
+        exit 1
+      fi
+      ${pkgs.wl-clipboard}/bin/wl-copy --type image/png < "$file"
       ${pkgs.libnotify}/bin/notify-send "Screenshot saved" "$(basename "$file")"
     '')
     (pkgs.writeShellScriptBin "screenshot-annotate" ''

--- a/modules/home-manager/desktop/niri-noctalia.nix
+++ b/modules/home-manager/desktop/niri-noctalia.nix
@@ -204,22 +204,38 @@ in
       mkdir -p "$dir"
       file="$dir/$(date +%Y-%m-%d_%H-%M-%S).png"
 
-      win_data=$(${pkgs.niri}/bin/niri msg -j windows | ${pkgs.jq}/bin/jq '[.[] | select(.is_focused)] | first')
+      all_win=$(${pkgs.niri}/bin/niri msg -j windows)
+      win_data=$(echo "$all_win" | ${pkgs.jq}/bin/jq '[.[] | select(.is_focused)] | first')
       if [ -z "$win_data" ] || [ "$win_data" = "null" ]; then
         ${pkgs.libnotify}/bin/notify-send "Screenshot error" "No focused window"
         exit 1
       fi
 
-      out_name=$(echo "$win_data" | ${pkgs.jq}/bin/jq -r '.output')
-      win_x=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.geometry.x // 0')
-      win_y=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.geometry.y // 0')
-      win_w=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.geometry.width // 0')
-      win_h=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.geometry.height // 0')
+      out_name=$(echo "$win_data" | ${pkgs.jq}/bin/jq -r '.output // empty')
+      if [ -z "$out_name" ]; then
+        out_name=$(${pkgs.niri}/bin/niri msg -j focused-output | ${pkgs.jq}/bin/jq -r '.name')
+      fi
+
+      col=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.pos_in_scrolling_layout[0]')
+      row=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.pos_in_scrolling_layout[1]')
+      win_w=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.window_size[0]')
+      win_h=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.window_size[1]')
+      off_x=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.window_offset_in_tile[0]')
+      off_y=$(echo "$win_data" | ${pkgs.jq}/bin/jq '.layout.window_offset_in_tile[1]')
 
       if [ "$win_w" -eq 0 ] || [ "$win_h" -eq 0 ]; then
         ${pkgs.libnotify}/bin/notify-send "Screenshot error" "Could not get window geometry"
         exit 1
       fi
+
+      gap=8
+      prev_h=$(echo "$all_win" | ${pkgs.jq}/bin/jq \
+        "[.[] | select(.output == \"$out_name\" and .layout.pos_in_scrolling_layout[0] == $col and .layout.pos_in_scrolling_layout[1] < $row) | .layout.tile_size[1]] | add // 0")
+      prev_w=$(echo "$all_win" | ${pkgs.jq}/bin/jq \
+        "[.[] | select(.output == \"$out_name\" and .layout.pos_in_scrolling_layout[0] < $col and .layout.pos_in_scrolling_layout[1] == $row) | .layout.tile_size[0]] | add // 0")
+
+      win_x=$(echo "$prev_w $col $gap $off_x" | ${pkgs.coreutils}/bin/awk '{print int($1 + ($2 - 1) * $3 + $3 + $4)}')
+      win_y=$(echo "$prev_h $row $gap $off_y" | ${pkgs.coreutils}/bin/awk '{print int($1 + ($2 - 1) * $3 + $3 + $4)}')
 
       ${pkgs.grim}/bin/grim -o "$out_name" - | \
         ${pkgs.imagemagick}/bin/convert - -crop "$win_w"x"$win_h"+"$win_x"+"$win_y" "$file"

--- a/modules/home-manager/vscode/settings-linux.json
+++ b/modules/home-manager/vscode/settings-linux.json
@@ -277,5 +277,13 @@
   },
   "terminal.integrated.defaultProfile.linux": "fish",
   "workbench.activityBar.location": "top",
-  "git.suggestSmartCommit": false
+  "git.suggestSmartCommit": false,
+  "yaml.disableSchemaDetection": [
+    "**/.github/workflows/*.yml",
+    "**/.github/workflows/*.yaml",
+    "**/.gitea/workflows/*.yml",
+    "**/.gitea/workflows/*.yaml",
+    "**/.forgejo/workflows/*.yml",
+    "**/.forgejo/workflows/*.yaml"
+  ]
 }


### PR DESCRIPTION
## Summary
- Replace `discord-tun` (TUN netns approach) with `discord-udp-proxy` (TPROXY/iptables-based UDP proxy via Xray)
- Wrap Discord with `--proxy-server=socks5://127.0.0.1:10808 --disable-quic` and unset all proxy env vars
- Add `screenshot-window` script (`Mod+Print`): captures focused window via grim+imagemagick crop, copies to clipboard, saves to `~/Pictures/Screenshots/`
  - Gets window geometry from `niri msg -j windows` layout fields (no `.geometry` field in Niri API)
  - Calculates x,y position from tile positions, sizes, and gaps
- Add `imagemagick` to desktop packages for crop operation
- **MCP servers preserved**: docker, systemd, nixos, vbox, telegram all intact

## Files changed
- `hosts/desktop-pc/system-modules/default.nix` — swap discord-tun → discord-udp-proxy
- `hosts/desktop-pc/system-modules/discord-udp-proxy.nix` — new: Xray UDP TPROXY service for Discord voice
- `modules/home-manager/apps/discord.nix` — wrapped discord with SOCKS5 proxy + env cleanup
- `modules/home-manager/desktop/desktop-apps.nix` — add imagemagick
- `modules/home-manager/desktop/niri-noctalia.nix` — add screenshot-window script + Mod+Print keybind

## Validation
- `nix flake check` passes

## Rebuild
```
sudo nixos-rebuild test --flake .#desktop-pc
home-manager switch --flake .#snrx@desktop-pc
```

## Rollback
- `git revert` the merge commit, or
- Select previous generation at boot