### PR TITLE
feat: add firejail sandboxing tool

### DIFF
--- a/hosts/desktop-pc/configuration.nix
+++ b/hosts/desktop-pc/configuration.nix
@@ -131,6 +131,7 @@
     vicinae
     libimobiledevice
     ifuse
+    firejail
   ];
 
   # Enabled services


### PR DESCRIPTION
- Add firejail to environment.systemPackages
- Provides application sandboxing and security isolation
- To activate: `sudo nixos-rebuild switch --flake .#desktop-pc`