### PR TITLE
fix: restrict focus-follows-mouse to on-screen windows

### DIFF
--- a/modules/home-manager/desktop/niri-noctalia.nix
+++ b/modules/home-manager/desktop/niri-noctalia.nix
@@ -341,7 +341,7 @@ in
             natural-scroll
         }
 
-        focus-follows-mouse
+        focus-follows-mouse max-scroll-amount="0%"
     }
 
 


### PR DESCRIPTION
## Summary
- Add `max-scroll-amount=\0%\` to `focus-follows-mouse` in niri config
- Prevents unintended focus switching when mouse crosses monitor edges
- Fixes annoyance where moving mouse between screens triggers window switch